### PR TITLE
Use SlimerJS 0.906 instead of 0.9.6-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "officegen": "^0.2.9",
-    "slimerjs": "^0.9.6-2",
+    "slimerjs": "^0.906.0",
     "sync-exec": "^0.6.2",
     "tmp": "0.0.28"
   }


### PR DESCRIPTION
Hi senshu,

when trying to install Sozi-export (on Ubuntu 16.04.02, via npm 3.10.10) I got an error related to the download of SlimerJs package. Turns out that the download URL tries to redirect the request, which causes a 301 error (see detailed error msg below).

I know the error is not on your end and I should maybe rather file it with the SlimerJs guys, but I just wanted to let you know that changing the SlimerJs dependency from version `0.9.6-2` to `0.906.0` worked for me to get rid of that error. It also successfully converted a HTML presentation to PDF with that version.

I also tried SlimerJs 0.10.2, which installed successfully, but threw an error when trying to run `sozi-to-pdf`.

Have a nice day
-- Harry

---
The console output from `sudo npm install -g sozi-export` (using the official repo):
```
npm WARN deprecated slimerjs@0.9.6: Switch to 0.10.2 when it's released
npm WARN deprecated npmconf@2.1.2: this package has been reintegrated into npm and is now out of date with respect to npm
\
> slimerjs@0.9.6 install /usr/lib/node_modules/sozi-export/node_modules/slimerjs
> node install.js

Looks like an `npm install -g`; unable to check for already installed version.
Downloading http://download.slimerjs.org/releases/0.9.6/slimerjs-0.9.6-linux-x86_64.tar.bz2
Saving to /usr/lib/node_modules/sozi-export/node_modules/slimerjs/slimerjs/slimerjs-0.9.6-linux-x86_64.tar.bz2
Receiving...
Error requesting archive.
Status: 301
Request options: {
  "protocol": "http:",
  "slashes": true,
  "auth": null,
  "host": "download.slimerjs.org",
  "port": null,
  "hostname": "download.slimerjs.org",
  "hash": null,
  "search": null,
  "query": null,
  "pathname": "/releases/0.9.6/slimerjs-0.9.6-linux-x86_64.tar.bz2",
  "path": "/releases/0.9.6/slimerjs-0.9.6-linux-x86_64.tar.bz2",
  "href": "http://download.slimerjs.org/releases/0.9.6/slimerjs-0.9.6-linux-x86_64.tar.bz2"
}
Response headers: {
  "server": "nginx/1.10.3",
  "date": "Fri, 09 Jun 2017 11:16:23 GMT",
  "content-type": "text/html",
  "content-length": "185",
  "connection": "close",
  "location": "https://download.slimerjs.org/releases/0.9.6/slimerjs-0.9.6-linux-x86_64.tar.bz2"
}
Make sure your network and proxy settings are correct.
npm ERR! Linux 4.4.0-79-generic
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install" "-g"
npm ERR! node v4.8.3
npm ERR! npm  v2.15.11
npm ERR! code ELIFECYCLE

npm ERR! slimerjs@0.9.6 install: `node install.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the slimerjs@0.9.6 install script 'node install.js'.
npm ERR! This is most likely a problem with the slimerjs package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node install.js
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs slimerjs
npm ERR! Or if that isn't available, you can get their info via:
npm ERR! 
npm ERR!     npm owner ls slimerjs
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /home/harry/src/Sozi-export/npm-debug.log
```